### PR TITLE
Fixing/adding missing texts

### DIFF
--- a/Assets/sources/Missions/Core/CORE4_EN.json
+++ b/Assets/sources/Missions/Core/CORE4_EN.json
@@ -245,6 +245,18 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: Blast 2{H}\n{B}: Pierce 2",
+          "bonuses": "",
+          "keywords": "Massive\r\n+3 Accuracy",
+          "abilities": "Targeting Computer: While attacking, you may reroll 1 attack die.\r\nEpic Arsenal: Your attack pool consists of any combination of 3 attack dice. You may not roll more than 2 dice of a single color.\r\nAwkward: You cannot attack adjacent figures.",
+          "customText": "",
+          "cardName": "Hijacked AT-ST",
+          "GUID": "90f056ce-4227-4853-afc4-18cadf5dab9f",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Hijacked AT-ST"
+        },
+        {
           "tbText": "{-} The <color=\"red\">Hijacked AT-ST</color> is a Rebel figure. Heroes control it as an ally.\r\n{-} The <color=\"red\">AT-ST</color> gains the following ability: <i><b>Epic Arsenal:</b> Your attack pool consists of any combination of 3 attack dice. You may not roll more than 2 dice of a single color.</i>\r\n{-} Instead of activating as normal, the <color=\"red\">AT-ST</color> performs one action after each hero's activation.\r\n{-} The mission will progress when a Rebel figure enters the Clearing.",
           "GUID": "dba1eefa-8488-413e-bae3-a5a52ee5dd12",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Empire/EMPIRE15_EN.json
+++ b/Assets/sources/Missions/Empire/EMPIRE15_EN.json
@@ -136,6 +136,42 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X-8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (1)",
+          "GUID": "a7b11f76-753b-4bd2-965c-230e7b7ef71b",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (1)"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X-8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (2)",
+          "GUID": "ae80271c-5911-4927-9690-945b6a755f1a",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (2)"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X-8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (3)",
+          "GUID": "0b8cb811-0b15-4f13-b697-087d7232c4a7",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (3)"
+        },
+        {
           "translatedEntityProperties": [
             {
               "entityName": "X8 Green 1",
@@ -247,6 +283,18 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (4)",
+          "GUID": "aa4d9ac7-b2af-469c-8905-0c3992c45780",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (4)"
+        },
+        {
           "shortText": "Download the schematics.",
           "longText": null,
           "GUID": "7736a90e-7eb1-4460-92dc-26e5caca51f5",
@@ -271,37 +319,114 @@
       "eventName": "EoR Deployment 1",
       "GUID": "9edbcf57-212b-4e81-8cba-4aeee15b6c31",
       "eventText": "Countless conveyor belts and heavy machinery are churning out more X-8 blaster droids.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (6)",
+          "GUID": "1fb4a79b-44c4-4187-8c4c-d5e404b0beb0",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (6)"
+        }
+      ]
     },
     {
       "eventName": "EoR Deployment 2",
       "GUID": "8528ea51-2b60-44c5-9990-378d47fe7508",
       "eventText": "Countless conveyor belts and heavy machinery are churning out more X-8 blaster droids.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (7)",
+          "GUID": "51945b84-80d9-443b-adcb-9ef0f4dc6a2c",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (7)"
+        }
+      ]
     },
     {
       "eventName": "EoR Deployment 3",
       "GUID": "886fb4e6-e10c-46bb-aa53-8ebfa852ed82",
       "eventText": "Countless conveyor belts and heavy machinery are churning out more X-8 blaster droids.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (8)",
+          "GUID": "3d86c5cc-1f31-4808-b80c-2c52f67d6bff",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (8)"
+        }
+      ]
     },
     {
       "eventName": "EoR Deployment 4",
       "GUID": "48f129b1-8ed9-4e87-acbe-936b5ed6915d",
       "eventText": "Countless conveyor belts and heavy machinery are churning out more X-8 blaster droids.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (9)",
+          "GUID": "46ef5254-fdd5-4367-b997-92a105a90d15",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (9)"
+        }
+      ]
     },
     {
       "eventName": "EoR Deployment 5",
       "GUID": "3e1a02e8-146f-489a-b2a5-1af788acb41f",
       "eventText": "Countless conveyor belts and heavy machinery are churning out more X-8 blaster droids.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (10)",
+          "GUID": "84fc6168-cd6b-4a66-a234-0c171fe52e43",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (10)"
+        }
+      ]
     },
     {
       "eventName": "Rightful Owner",
       "GUID": "259dc60e-234b-4db0-8490-f3fc6f69224d",
       "eventText": "Finally! Your datapad chimes to signal that the download has finished. The schematics are yours. Now to stop the factory from producing a droid ever again.",
       "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 1",
+          "bonuses": "ELECTRIC SHOCK: After this figure attacks, each Rebel figure adjacent to an X-8 blaster droid suffers 1 {C}.\r\nFIND WEAKNESS: The attack of this figure gains Pierce 1.",
+          "keywords": "+1 {H}\r\n+1 {G}",
+          "abilities": "HEALTH: The X8 blaster droid has *1* Health.",
+          "customText": "{-} The attack gains +1 {H}.\r\n{Q} Move 3 to attack the Rebel adjacent to the most X8 blaster droids. Apply +1 {H} for each X8 blaster droid adjacent to the defender except for the attacker.\r\n{A} Move 2 toward the Rebel adjacent to the most X8 blaster droids.\r\n{A} Move 4 toward the Rebel adjacent to the most X8 blaster droids.",
+          "cardName": "X-8 blaster droid (5)",
+          "GUID": "fbcbaaf7-8091-4e13-a39f-0984faa5ceb8",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: X-8 blaster droid (5)"
+        },
         {
           "tbText": "Now that you have downloaded the schematics, you turn your attention towards the terminals.\r\n\r\n{-} Rebel figures can attack a terminal (Health: *1*, Defense: 1 {G}) or interact with a terminal ({K} or {I}) to destroy it.\r\n{-} After the red terminals are destroyed, no more blaster droids are being produced.\r\n{-} The Rebels win when all terminals and all X-8 blaster droids are destroyed.",
           "GUID": "f6f7e2a1-a5fe-45b4-8f75-bb5dbf8a8a30",

--- a/Assets/sources/Missions/Hoth/HOTH11_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH11_EN.json
@@ -168,6 +168,18 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: +3 Accuracy\r\n{B}: Stun\r\n{B}: Focus\r\n{B}: +2 {H}",
+          "bonuses": "DEFENSE STUDY: Discard 1 Imperial mission token from the sheet / card of the closest Rebel figure with an Imperial mission token on it. Ivan Talos gains +2 {g}.\r\nIMPROVISATION: During this activation, this figure can use IMPROVED CLOSE QUARTERS on Rebel figures without Imperial mission tokens on their sheets.\r\nATTACK STUDY: Distribute X {h} as evenly as possible between Imperial figures within 3 spaces of this figure, where X is the number of Imperial mission tokens on hero sheets.",
+          "keywords": "+1 {G}\r\n+*1* Health",
+          "abilities": "Know Your Enemy:If a Rebel figure with an Imperial mission token on its hero sheet / deployment card is attacking Ivan Talos, apply an additional +1 {G} to the defense results.",
+          "customText": "{Q} IMPROVED CLOSE QUARTERS: Move 2 to interact with a Rebel and discard 1 Imperial mission token from that Rebel's sheet / card. Choose the best weapon that Rebel is carrying and perform 2 attacks using that weapon. \r\n{-} If this figure did not perform IMPROVED CLOSE QUARTERS, discard 1 Imperial mission token from the closest Rebel with an Imperial token on its sheet / card. That hero suffers 2 {C}.\r\n{A} ORDER: Another Imperial figure with a figure cost of 6 or less that can perform an attack attacks {rebel}.\r\n{Q} If this figure did not use ORDER, move 3 to attack {rebel}.\r\n{Q} Move 1 to attack {rebel}.\r\n{A} Move 3 to engage the other Imperial figure with the most Health remaining.\r\n{A} If this figure is not adjacent to another Imperial figure, move 4 to reposition 5.\r\n{-} COWER: If adjacent to another Imperial figure, recover 2 {H}. The adjacent non-<color=\"red\">Focused</color> Imperial figure with the highest figure cost becomes <color=\"red\">Focused</color>.",
+          "cardName": "Ivan Talos",
+          "GUID": "1615cd73-6182-43f9-b953-c1fa138e0060",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Ivan Talos"
+        },
+        {
           "tbText": "Two bodyguards take their positions in front of Verana's brother.",
           "GUID": "aa8a3c81-928c-4268-8089-3f99fadceab5",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Hoth/HOTH14_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH14_EN.json
@@ -130,6 +130,18 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: +3 Accuracy\n{B}: Blast 2 {H}\n{B}: +2 {H}",
+          "bonuses": "SQUAD TRAINING: While attacking, each figure in this group gains Pierce 1. If the target has already been attacked during this group's activation, they gain Pierce 2 instead.\r\nSCORCHED EARTH: After this activation, place another fire in an empty space adjacent to you.",
+          "keywords": "",
+          "abilities": "COMPOSITE PLATING:While defending, if the attacker is 4 or more spaces away, apply +1 {G} to the defense roll.\r\nFIREPROOF: This figure does not suffer {H} from entering spaces containing a fire. It can voluntarily end its movement in a space containing a fire.",
+          "customText": "{-} LAST STAND: If there are fewer than 3 figures in this group, become <color=\"red\">Focused</color>. Limit once per group activation.\r\n{-} FIREPROOF: This figure does not suffer {H} from entering spaces containing a fire. It can voluntarily end its movement in a space containing a fire.\r\n{Q} Move 1 to attack {rebel}.\r\n{A} Move 2 toward the closest Homestead Tile without a fire.\r\n{A} Move 4 toward the closest Homestead Tile without a fire.\r\n{-} Place 1 fire in an empty space adjacent to you. If possible, target a space on a Homestead Tile without a fire.",
+          "cardName": "Incinerator Troopers",
+          "GUID": "a8f36c26-b825-48c8-94fb-bd5126dfe023",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Incinerator Troopers"
+        },
+        {
           "translatedEntityProperties": [
             {
               "entityName": "Incinerator 1",

--- a/Assets/sources/Missions/Hoth/HOTH1_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH1_EN.json
@@ -633,7 +633,20 @@
       "eventName": "The General",
       "GUID": "cce142e4-d999-4fb6-9cb5-78a1aa3a783f",
       "eventText": "Booms and crashes rattle the air as buildings continue to fall in ruin under the onslaught of the Imperial force. Then, added to the noise are large thuds that begin to shake the ground as a massive machine of war lumbers toward your skirmish.\r\n\r\nYou hear the amplified voice of General Sorin emanating from this AT-ST, shouting orders to his troops with terrifying ferocity. With flame and destruction in his wake, he aims the large blasters of his vehicle in your direction.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Blast 2 {H}\r\n{B} Stun\r\n{B} Focus\n{B}: Pierce 2",
+          "bonuses": "MORTAR: At the start of this activation, each hero may test {K}. If a hero is in an exterior space, it may test {J} instead. Each hero that does not pass becomes <color=\"red\">Weakened</color>.\r\nFOCUS: At the start of this activation, this figure becomes <color=\"red\">Focused</color>.\r\nGRENADE LAUNCHER: After this figure resolves an attack, roll 1 yellow die. Each Rebel within X spaces of the target suffers 1 {H} for each activation token. X is the Accuracy result.",
+          "keywords": "Massive\r\n+5 Accuracy\r\n+1 {H}",
+          "abilities": "Awkward: Sorin's AT-ST cannot attack adjacent figures.",
+          "customText": "{-} BOMBARDMENT: This figure’s attacks do not require line of sight or Accuracy, and each gains Blast 1 {H}.\r\n{Q} Attack {rebel}.\r\n{A} Move 5 to reposition 2.\r\n{Q} Attack {rebel}.\r\n{A} Recover 2 {H}.\r\n{-} ADVANCED FIREPOWER: Each adjacent Imperial figure becomes <color=\"red\">Focused</color>.",
+          "cardName": "Sorin's AT-ST",
+          "GUID": "6b70c8ad-8edb-43b6-90e2-501a0b7ef5f5",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Sorin's AT-ST"
+        }
+      ]
     },
     {
       "eventName": "Target change",

--- a/Assets/sources/Missions/Jabba/JABBA10_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA10_EN.json
@@ -311,6 +311,18 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: +1 {H}\n{B}: +1 Accuracy",
+          "bonuses": "",
+          "keywords": "+1 Accuracy",
+          "abilities": "Raider: While attacking, you may choose 1 die. The player that rolled that die must reroll that die.",
+          "customText": "",
+          "cardName": "Jabba's Weequay Mercenaries",
+          "GUID": "170ad533-9213-4ee5-974f-0570812afacb",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Jabba's Weequay Mercenaries"
+        },
+        {
           "repositionText": "Block access to the door.",
           "GUID": "0eb26a29-fc79-4401-99c2-68b566e55d03",
           "eventActionType": 17,

--- a/Assets/sources/Missions/Jabba/JABBA13_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA13_EN.json
@@ -130,6 +130,42 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy",
+          "bonuses": "OLD RIVALRY: If Vinto Hreeda can be attacked, he becomes the target of all attacks during this activation. In this case, add 1 green die to the first attack.\r\nSHOT ON THE RUN: After the first Move instruction during this activation is carried out, 1 Rebel figure within 3 spaces and line of sight of the Rodian pirate suffers 1 {C}.\r\nLONG-RANGE SHOT: The Rodian pirates gain +3 Accuracy.",
+          "keywords": "+1 {G}",
+          "abilities": "",
+          "customText": "{Q} Move 3 to attack {rebel}. Apply +1 {H} to the attack results.\r\n{A} Move 1 to reposition 3.\r\n{A} Move 5 to reposition 3.",
+          "cardName": "Rodian Pirates",
+          "GUID": "b9966670-7ccb-4d24-9941-a906d65f344e",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Rodian Pirates"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy",
+          "bonuses": "OLD RIVALRY: If Vinto Hreeda can be attacked, he becomes the target of all attacks during this activation. In this case, add 1 green die to the first attack.\r\nSHOT ON THE RUN: After the first Move instruction during this activation is carried out, 1 Rebel figure within 3 spaces and line of sight of the Rodian pirate suffers 1 {C}.\r\nLONG-RANGE SHOT: The Rodian pirates gain +3 Accuracy.",
+          "keywords": "+1 {G}",
+          "abilities": "",
+          "customText": "{Q} Move 3 to attack {rebel}. Apply +1 {H} to the attack results.\r\n{A} Move 1 to reposition 3.\r\n{A} Move 5 to reposition 3.",
+          "cardName": "Rodian Pirates",
+          "GUID": "be7475ad-7259-4917-9407-f572aa34af29",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Rodian Pirates"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy",
+          "bonuses": "OLD RIVALRY: If Vinto Hreeda can be attacked, he becomes the target of all attacks during this activation. In this case, add 1 green die to the first attack.\r\nSHOT ON THE RUN: After the first Move instruction during this activation is carried out, 1 Rebel figure within 3 spaces and line of sight of the Rodian pirate suffers 1 {C}.\r\nLONG-RANGE SHOT: The Rodian pirates gain +3 Accuracy.",
+          "keywords": "+1 {G}",
+          "abilities": "",
+          "customText": "{Q} Move 3 to attack {rebel}. Apply +1 {H} to the attack results.\r\n{A} Move 1 to reposition 3.\r\n{A} Move 5 to reposition 3.",
+          "cardName": "Rodian Pirates",
+          "GUID": "183c341d-6ef2-477c-8100-cf81f2c370ed",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Rodian Pirates"
+        },
+        {
           "tbText": "Vinto remains impassive, hand on his blaster. \"This is no longer my home, and you are no longer my friend.\" The pirates move to protect the stolen supplies.",
           "GUID": "6a079214-0c17-409d-afd7-8dd65c47d6f3",
           "eventActionType": 16,
@@ -601,6 +637,30 @@
           "GUID": "4675b444-7c5e-4a29-9239-628dcbd98a46",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy",
+          "bonuses": "OLD RIVALRY: If Vinto Hreeda can be attacked, he becomes the target of all attacks during this activation. In this case, add 1 green die to the first attack.\r\nSHOT ON THE RUN: After the first Move instruction during this activation is carried out, 1 Rebel figure within 3 spaces and line of sight of the Rodian pirate suffers 1 {C}.\r\nLONG-RANGE SHOT: The Rodian pirates gain +3 Accuracy.",
+          "keywords": "+1 {G}",
+          "abilities": "",
+          "customText": "{Q} Move 3 to attack {rebel}. Apply +1 {H} to the attack results.\r\n{A} Move 1 to reposition 3.\r\n{A} Move 5 to reposition 3.",
+          "cardName": "Rodian Pirates",
+          "GUID": "64bae351-2e25-4017-945e-fc695d23036a",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Rodian Pirates"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy",
+          "bonuses": "OLD RIVALRY: If Vinto Hreeda can be attacked, he becomes the target of all attacks during this activation. In this case, add 1 green die to the first attack.\r\nSHOT ON THE RUN: After the first Move instruction during this activation is carried out, 1 Rebel figure within 3 spaces and line of sight of the Rodian pirate suffers 1 {C}.\r\nLONG-RANGE SHOT: The Rodian pirates gain +3 Accuracy.",
+          "keywords": "+1 {G}",
+          "abilities": "",
+          "customText": "{Q} Move 3 to attack {rebel}. Apply +1 {H} to the attack results.\r\n{A} Move 1 to reposition 3.\r\n{A} Move 5 to reposition 3.",
+          "cardName": "Rodian Pirates",
+          "GUID": "b594acda-e6f3-4dec-bed2-a465924cf2dc",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Rodian Pirates"
         },
         {
           "tbText": "{-} The Rebels win when all Rodian pirates have been defeated.",

--- a/Assets/sources/Missions/Jabba/JABBA1_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA1_EN.json
@@ -363,6 +363,18 @@
           "eaName": "Text Box"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy\r\n{B} +2 {H}\n{B}: Focus",
+          "bonuses": "INSPIRE THE TROOPS: At the start of this activation, each Imperial figure within 3 spaces of this figure discards 1 Harmful condition. Each of those figures that did not discard a condition recovers 1 {H}.\r\nSUPPORT THE CAPTAIN: At the start of this activation, this figure recovers 1 {H} for each Imperial figure within 3 spaces of it.",
+          "keywords": "+1 {F}",
+          "abilities": "",
+          "customText": "{-} SQUAD COMMAND: The closest other Imperial figure that isn’t <color=\"red\">Focused</color> becomes <color=\"red\">Focused</color>.\r\n{A} FIRE AT WILL: The closest other Imperial figure that can perform an attack attacks {rebel}.\r\n{Q} Move 4 to attack {rebel}.\r\n{A} Move 2 to reposition 5.\r\n{A} Move 6 to reposition 5.",
+          "cardName": "Terro (Stormtrooper)",
+          "GUID": "560d29b4-d93c-40da-9de8-c6b168ff986e",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Terro (Stormtrooper)"
+        },
+        {
           "tbText": "{-} The door is locked.\r\n{-} A Rebel figure can interact with the terminal to discard it. When the terminal is discarded and Terro is defeated, the door unlocks.\r\n{-} The mission will progress when the door opens.",
           "GUID": "2773d961-c409-4388-af2a-4c0920e344d5",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Jabba/JABBA3_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA3_EN.json
@@ -106,6 +106,18 @@
       "eventText": "Jabba’s convoy arrives with a squad of Gamorreans and Weequay. The civilians look frightened at the arrival of the motley and intimidating assortment of mercenaries, but you assure them that they are here to help. Finally, Bib Fortuna emerges from the shuttle and begins to set up a plan with you.\r\n\r\n“We have coordinates for a small base not far from here where we believe Terro is preparing his ambush,” he informs you. “We'll leave a smalll garrison here for protection in your absence, and then you can storm their base and take them by surprise. If you can slice their system, you should be able to override their energy controls and trigger a  self-destruct of the base.”\r\n\r\nYou gather your gear and kiss your family goodbye before trudging through the forest with a pair of Gamorreans Bib Fortuna identified as the captains.",
       "eventActions": [
         {
+          "repositionInstructions": "",
+          "surges": "{B}: Cleave 2 {H}",
+          "bonuses": "",
+          "keywords": "Reach",
+          "abilities": "Gamorrean Honor Guard:While defending during a {O} attack, apply +1 {G} to the defense results.\nProfessional:While attacking, you may reroll 1 attack die.",
+          "customText": "",
+          "cardName": "Gamorrean Guards",
+          "GUID": "3d9f4367-3ac4-4ba0-8324-96dd66ac5b1a",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Gamorrean Guards"
+        },
+        {
           "tbText": "{-} Deploy the heroes to the blue highlighted space.\r\n{-} The door is locked.\r\n{-} When a hero withdraws, he is incapacitated instead, When activating, he receives only 1 action and can only use that action to perform a move.",
           "GUID": "1181a458-600d-4a86-9e12-786009ec3f77",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Lothal/LOTHAL4_EN.json
+++ b/Assets/sources/Missions/Lothal/LOTHAL4_EN.json
@@ -540,7 +540,7 @@
     {
       "eventName": "Commandeered",
       "GUID": "879d40c3-00b8-4e8c-9322-29c6f4cea4a4",
-      "eventText": "You wrestle control from the Imperials and take the seat of the pilot yourself. \"Well done!\", shouts Wolffe over com. \"Now let's bring the fight to them, eh?\" Outside, you can see Wolffe's AT-AT slowly turning towards his former pursuers. The hunt is on.\r\n\r\n{-} The mission no longer ends at the end of Round 5.\r\n{-} Flip one Imperial AT-AT to the Rebel side. This is the captured AT-AT. \r\n{-} Rebel AT-ATs can now attack.",
+      "eventText": "You wrestle control from the Imperials and take the seat of the pilot yourself. \"Well done!\", shouts Wolffe over com. \"Now let's bring the fight to them, eh?\" Outside, you can see Wolffe's AT-AT slowly turning towards his former pursuers. The hunt is on.\r\n\r\n{-} Flip one Imperial AT-AT to the Rebel side. This is the captured AT-AT. \r\n{-} Rebel AT-ATs can now attack.",
       "eventActions": [
         {
           "tbText": "{-} At the start of the captured AT-AT's activation, a hero on or adjacent to the steering (blue terminal) may test {I} or {J}. If successful, the captured AT-AT gains 1 movement point.\r\n{-} At the start of the captured AT-AT's activation, a hero on or adjacent to the fire control (red terminal) may test {I} or {K}. If successful, the captured AT-AT gains 1 {h}.\r\n{-} When a Rebel AT-AT is defeated, click the highlight on the Seelos map and select \"Rebel AT-AT defeated\". When an Imperial AT-AT is defeated, click the highlight on the Seelos map and select \"Imperial AT-AT defeated\".\r\n{-} The Rebels win when the Imperial AT-AT is defeated.",

--- a/Assets/sources/Missions/Other/OTHER39_EN.json
+++ b/Assets/sources/Missions/Other/OTHER39_EN.json
@@ -100,6 +100,18 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 2",
+          "bonuses": "CHARGE GENERATORS: This figure gains 1 {h}.\nAUTOMATED REPAIRS: This figure recovers 2 {H}.",
+          "keywords": "+5 Health\r\n+4 Accuracy",
+          "abilities": "None:None",
+          "customText": "{Q} Move 2 to attack {rebel}.\r\n{A} Move 2 away from the Rebels.\r\n{A} Move 4 away from the Rebels.\r\n{-} This figure gains 1 {g}.",
+          "cardName": "E-XD Infiltrator Droid",
+          "GUID": "ae59cebd-1c6b-4a4d-8338-88fe0c34020b",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: E-XD Infiltrator Droid"
+        },
+        {
           "tbText": "{-} The Imperial mission token represents the E-XD Infiltrator Droid.\r\n{-} If the E-XD has been defeated, a figure can interact with the door ({K} or {I}) to try and open it. That figure may suffer 1 {C} during that test to reroll any number of dice.\r\n{-} The mission will progress when the door opens.\r\n{-} The Rebels lose when all heroes are wounded.",
           "GUID": "323e6074-8a06-4b69-99f2-40751a8b4757",
           "eventActionType": 16,
@@ -344,6 +356,18 @@
           "GUID": "4e89238c-20e4-454e-bcc5-905755bc1541",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: Pierce 2",
+          "bonuses": "CHARGE GENERATORS: This figure gains 1 {h}.\r\nAUTOMATED REPAIRS: This figure recovers 2 {H}.",
+          "keywords": "+5 Health\r\n+4 Accuracy\r\n+1 {G}",
+          "abilities": "None:None",
+          "customText": "{Q} Move 2 to attack {rebel}.\r\n{A} Move 2 away from the Rebels.\r\n{A} Move 4 away from the Rebels.\r\n{-} This figure gains 1 {g}.",
+          "cardName": "E-XD Infiltrator Droid",
+          "GUID": "47e01a30-efc4-40ab-85e1-638a0acdf7d5",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: E-XD Infiltrator Droid"
         },
         {
           "tbText": "{-} When the E-XD would be defeated, it is incapacitated instead. \r\n{-} The mission will progress when the E-XD is incapacitated.",

--- a/Assets/sources/Missions/Other/OTHER8_EN.json
+++ b/Assets/sources/Missions/Other/OTHER8_EN.json
@@ -447,19 +447,58 @@
       "eventName": "Deployment Yes 1",
       "GUID": "05581a39-fa33-46f3-8f1a-d624d56f928f",
       "eventText": "The legion of troopers is unending. More soldiers rush in to stop you.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy\r\n{B} +1 {H}",
+          "bonuses": "SQUAD TRAINING: While attacking, each figure in this group gains Pierce 1. If the target has already been attacked during this group's activation, they gain Pierce 2 instead.\r\nVADER'S FINEST: When the first figure in this group declares an attack, add 1 green die to the attack pool.\r\nREINFORCE: After this group's activation, reinforce 1 defeated figure from this group as close as possible to another figure in this group.",
+          "keywords": "",
+          "abilities": "",
+          "customText": "{Q} Move 4 to attack {rebel}.\r\n{A} Move 2 to reposition 4.\r\n{A} Move 6 to reposition 4.",
+          "cardName": "Stormtrooper",
+          "GUID": "2d3c77b0-60dc-4e3e-ad90-7d3b9ad31439",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Stormtrooper"
+        }
+      ]
     },
     {
       "eventName": "Deployment Yes 2",
       "GUID": "07b2bede-72cc-43a7-bb2c-bbf502b754f2",
       "eventText": "The legion of troopers is unending. More soldiers rush in to stop you.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy\r\n{B} +1 {H}",
+          "bonuses": "SQUAD TRAINING: While attacking, each figure in this group gains Pierce 1. If the target has already been attacked during this group's activation, they gain Pierce 2 instead.\r\nVADER'S FINEST: When the first figure in this group declares an attack, add 1 green die to the attack pool.\r\nREINFORCE: After this group's activation, reinforce 1 defeated figure from this group as close as possible to another figure in this group.",
+          "keywords": "",
+          "abilities": "",
+          "customText": "{Q} Move 4 to attack {rebel}.\r\n{A} Move 2 to reposition 4.\r\n{A} Move 6 to reposition 4.",
+          "cardName": "Stormtrooper",
+          "GUID": "ebb5c471-b04b-4d18-9fcf-2a118dca4d0b",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Stormtrooper"
+        }
+      ]
     },
     {
       "eventName": "Deployment Yes 3",
       "GUID": "e03df45e-105e-4a16-9306-d4419f5be01c",
       "eventText": "The legion of troopers is unending. More soldiers rush in to stop you.",
-      "eventActions": []
+      "eventActions": [
+        {
+          "repositionInstructions": "",
+          "surges": "{B}: +2 Accuracy\r\n{B} +1 {H}",
+          "bonuses": "SQUAD TRAINING: While attacking, each figure in this group gains Pierce 1. If the target has already been attacked during this group's activation, they gain Pierce 2 instead.\r\nVADER'S FINEST: When the first figure in this group declares an attack, add 1 green die to the attack pool.\r\nREINFORCE: After this group's activation, reinforce 1 defeated figure from this group as close as possible to another figure in this group.",
+          "keywords": "",
+          "abilities": "",
+          "customText": "{Q} Move 4 to attack {rebel}.\r\n{A} Move 2 to reposition 4.\r\n{A} Move 6 to reposition 4.",
+          "cardName": "Stormtrooper",
+          "GUID": "ab30ab06-df4c-420d-9b87-38d2e96cfce2",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Stormtrooper"
+        }
+      ]
     },
     {
       "eventName": "The Legion - Deployment 2",

--- a/Assets/sources/Missions/Tutorials/TUTORIAL01_EN.json
+++ b/Assets/sources/Missions/Tutorials/TUTORIAL01_EN.json
@@ -114,6 +114,18 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "repositionInstructions": "",
+          "surges": "",
+          "bonuses": "",
+          "keywords": "",
+          "abilities": "",
+          "customText": "",
+          "cardName": "Leia Organa",
+          "GUID": "47097c07-5055-4fac-9d76-c9a7229e3e74",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Leia Organa"
+        },
+        {
           "tbText": "<color=\"yellow\">When an Ally or an Enemy is deployed, you search the Deployment cards for their respective card and place it somewhere in your play area. Then you deploy their figure.\r\n\r\nSome allies or enemies are customized by the app, though, and don't correspond to a printed deployment card or a miniature. In this case, the Rebel mission token represents Leia. You can right-click or double-click / tap an ally or enemy portrait to display their deployment card, whether custom or not. (Select the {J} icon, then try it out - however, there's not much to see on Leia's card yet.) \r\n\r\nEach ally group gets 1 activation. The Rebel players usually decide when to activate an ally, but for the purpose of this tutorial, let's activate Leia first. In a regular mission, players have full control over an ally's actions, but Leia has always been headstrong.</color>",
           "GUID": "60fa60fc-585c-4c5c-8154-a13160ebcc10",
           "eventActionType": 16,


### PR DESCRIPTION
While doing some translation work, I noticed that a small part of the CORE4 translation was missing (the "Custom Deployment: Hijacked AT-ST").
Investigating further, it appeared that more files were impacted.
Fixing them in this PR.

_More details:_
This issue can be more worrying because: if someone were to use the current version of the SagaTranslatorModern app, it could remove translated texts previously created.

Example:
 - CORE4_DE.json current size: 631 lines.
 - Open it with the SagaTranslatorModern app.
   (Notice the warning)
 - Don't do any change (let's pretend you opened it to fix a small typo anywhere in the texts).
 - Save.
 - the file is now 619 lines long, because the "Hijacked AT-ST" part (previously translated) has been removed.

I therefore reopened all the SagaMissions files from latest IC2 (v.2.2.3) with ICE, saved them to generate the latest *_EN.json files and I'm now copying them here in the SagaTranslatorModern app.
Tested and confirmed that it's fixing the issue.