### PR TITLE
Adding translation for the campaign help mockups

### DIFF
--- a/Assets/sources/ui.json
+++ b/Assets/sources/ui.json
@@ -228,7 +228,10 @@
     "agendaImperialUC": "The Empire sees you as a threat worth stopping. Draw a card from the Imperial Mission Deck and put it into play. If it is a forced mission, immediately play that mission. If it is a side mission, it becomes an active side mission.",
     "agendaRebelUC": "The Empire uses its resources elsewhere. Nothing happens.",
     "xpUC": "XP",
-    "costUC": "Cost"
+    "costUC": "Cost",
+	"missionTypeMockupUC": "Mission Type",
+	"missionNameMockupUC": "Mission Name",
+	"itemMockupUC": "Tier 1"
   },
   "uiLogger": {
     "textLabel": "Text Message",

--- a/Models/UI/UILanguage.cs
+++ b/Models/UI/UILanguage.cs
@@ -760,7 +760,7 @@ namespace Saga_Translator_V2
 
 	public class UICampaign : ObservableObject
 	{
-		private string _threatInfoUC, _modeIntroductionUC, _modeStoryUC, _modeSideUC, _forcedUC, _modeInterludeUC, _modeFinaleUC, _campaignNameUC, _customCampaign, _addForcedMissionUC, _tierUC, _selectMissionUC, _customUC, _creditsUC, _fameUC, _awardsUC, _campaignSetup, _itemsUC, _rewardsUC, _villainsUC, _alliesUC, _threat, _agendaUC, _modifyUC, _removeUC, _otherUC, _campaignUC, _generalUC, _heroUC, _personalUC, _campaignSetupUC, _campaignDescriptionUC, _sagaDescriptionUC, _classicDescriptionUC, _agendaMission, _agendaImperialUC, _agendaRebelUC, _xpUC, _costUC;
+		private string _threatInfoUC, _modeIntroductionUC, _modeStoryUC, _modeSideUC, _forcedUC, _modeInterludeUC, _modeFinaleUC, _campaignNameUC, _customCampaign, _addForcedMissionUC, _tierUC, _selectMissionUC, _customUC, _creditsUC, _fameUC, _awardsUC, _campaignSetup, _itemsUC, _rewardsUC, _villainsUC, _alliesUC, _threat, _agendaUC, _modifyUC, _removeUC, _otherUC, _campaignUC, _generalUC, _heroUC, _personalUC, _campaignSetupUC, _campaignDescriptionUC, _sagaDescriptionUC, _classicDescriptionUC, _agendaMission, _agendaImperialUC, _agendaRebelUC, _xpUC, _costUC, _missionTypeMockupUC, _missionNameMockupUC, _itemMockupUC;
 
 		public string threatInfoUC
 		{
@@ -917,6 +917,18 @@ namespace Saga_Translator_V2
 		public string costUC
 		{
 			get => _costUC; set => SetProperty( ref _costUC, value );
+		}
+		public string missionTypeMockupUC
+		{
+			get => _missionTypeMockupUC; set => SetProperty( ref _missionTypeMockupUC, value );
+		}
+		public string missionNameMockupUC
+		{
+			get => _missionNameMockupUC; set => SetProperty( ref _missionNameMockupUC, value );
+		}
+		public string itemMockupUC
+		{
+			get => _itemMockupUC; set => SetProperty( ref _itemMockupUC, value );
 		}
 	}
 


### PR DESCRIPTION
If you accept the associated PR for IC2 (https://github.com/GlowPuff/ImperialCommander2/pull/71).

This is the associated PR for the translator app, adding translation for the campaign help mockups.