### PR TITLE
Adding otherTarget to the translated mission files - Part2

### DIFF
--- a/AppModels/MissionPanelUIHelper.cs
+++ b/AppModels/MissionPanelUIHelper.cs
@@ -376,5 +376,26 @@ namespace Saga_Translator_V2
 
 			panel.Children.Add( UIFactory.Border( stackPanel ) );
 		}
+
+		public static void CreateGM2(int eaIdx, TranslatedEvent dataSource, StackPanel panel, bool isEnabled, bool useContext)
+		{
+			var ea = dataSource.eventActions[eaIdx] as TranslatedChangeTarget;
+			if (ea.otherTarget != null)
+			{
+				StackPanel stackPanel = new StackPanel();
+				stackPanel.Children.Add(UIFactory.SubHeading($"{ea.eaName}", Utils.missingTranslations.Contains(ea.GUID)));
+
+				stackPanel.Children.Add(UIFactory.TBlock("otherTarget"));
+				stackPanel.Children.Add(UIFactory.TBox(ea.otherTarget, null, true, isEnabled, (a, b) =>
+				{
+					if (useContext)
+					{
+						ea.otherTarget = (a as TextBox).Text.Trim();
+					}
+				}));
+
+				panel.Children.Add(UIFactory.Border(stackPanel));
+			}
+		}
 	}
 }

--- a/Assets/sources/Missions/Bespin/BESPIN1_EN.json
+++ b/Assets/sources/Missions/Bespin/BESPIN1_EN.json
@@ -471,6 +471,12 @@
           "eaName": "Change Objective"
         },
         {
+          "otherTarget": "the Rebel carrying the dead drop",
+          "GUID": "6a7f462e-0f05-49e6-9814-bf12e373bac9",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "repositionText": "Block access to the catwalk.",
           "GUID": "1a759d96-959d-4e7f-bb7f-d87b11f47194",
           "eventActionType": 17,

--- a/Assets/sources/Missions/Bespin/BESPIN3_EN.json
+++ b/Assets/sources/Missions/Bespin/BESPIN3_EN.json
@@ -347,6 +347,12 @@
           "eaName": "Change Reposition Instructions"
         },
         {
+          "otherTarget": "the Rebel figure closest to Agent Blaise",
+          "GUID": "d58dfec3-6537-43fa-a5cd-586b8d347326",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "Agent Blaise, who has been busy checking data on a terminal, looks up in surprise as you barge into the command center. He draws his weapon, a move quickly mirrored by his aide. ",
           "GUID": "4e0945ac-4637-4d06-8259-c0343b70833b",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Bespin/BESPIN6_EN.json
+++ b/Assets/sources/Missions/Bespin/BESPIN6_EN.json
@@ -554,7 +554,14 @@
       "eventName": "FtF Yes",
       "GUID": "3f099e0c-e7a2-4206-832f-4dddd9337417",
       "eventText": "The Duke looks up from his desk. “Davith, my boy, its so good to see you again. I hope you understand that keeping you in the dark was never personal. You were too valuable to the organization to risk losing.”",
-      "eventActions": []
+      "eventActions": [
+        {
+          "otherTarget": null,
+          "GUID": "eda13a57-327e-4733-8fc6-cbd540f8554e",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        }
+      ]
     },
     {
       "eventName": "FtF No",

--- a/Assets/sources/Missions/Core/CORE12_EN.json
+++ b/Assets/sources/Missions/Core/CORE12_EN.json
@@ -295,6 +295,12 @@
           "GUID": "70691985-cfc9-4cf6-aef0-87a184f58d6c",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": "the hero carrying the data core",
+          "GUID": "ec60074f-7e3a-4fb6-a011-0c57a1875462",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },

--- a/Assets/sources/Missions/Core/CORE14_EN.json
+++ b/Assets/sources/Missions/Core/CORE14_EN.json
@@ -117,6 +117,12 @@
           "GUID": "f7b125d1-360f-402b-b8c1-b52dd9377117",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": null,
+          "GUID": "6d60aae2-4920-4ffa-a783-db545534f424",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },
@@ -142,6 +148,12 @@
           "GUID": "6810a3e4-5576-4d79-9900-da3c833781f1",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": "the closest closed door",
+          "GUID": "0b66bfd3-bed6-4bed-8860-63afd80b77dd",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },
@@ -167,6 +179,12 @@
           "GUID": "b4f37196-a497-4c40-b039-4ca75b950b49",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": null,
+          "GUID": "45127d06-07ce-4c1a-b04d-bed9920fe327",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },
@@ -175,6 +193,12 @@
       "GUID": "fc04bc99-4637-44f2-8a96-2a9fe9e930df",
       "eventText": "The door slams shut, protecting Luke - for the moment. It won't withstand the onslaught for long.",
       "eventActions": [
+        {
+          "otherTarget": "the closest closed door",
+          "GUID": "38554f16-3677-4b65-9c91-0ea677fa5148",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
         {
           "translatedEntityProperties": [
             {
@@ -243,6 +267,12 @@
           "GUID": "bf3a2f63-b4d3-4e16-8099-7b465c4c3e54",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": null,
+          "GUID": "fce6eeb8-22e3-43c7-8969-df0100ef500f",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },

--- a/Assets/sources/Missions/Core/CORE20_EN.json
+++ b/Assets/sources/Missions/Core/CORE20_EN.json
@@ -157,6 +157,12 @@
           "eaName": "Change Mission Info"
         },
         {
+          "otherTarget": null,
+          "GUID": "89ef1ffc-99fe-40d9-a9b6-5cf6978cf2c6",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "translatedEntityProperties": [
             {
               "entityName": "AT-ST Token",

--- a/Assets/sources/Missions/Core/CORE27_EN.json
+++ b/Assets/sources/Missions/Core/CORE27_EN.json
@@ -268,6 +268,12 @@
           "eaName": "Deploy: DG006/Imperial Officer (Elite)"
         },
         {
+          "otherTarget": "the Rebel carrying the data core",
+          "GUID": "84b50882-5474-407b-958e-5860135de61d",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "newInstructions": "If the Courier is carrying the data core:\r\n\r\n{A} Move 4 towards the Entrance.\r\n{A} Move 4 towards the Entrance.\r\n\r\nIf the Courier is not carrying the data core:\r\n\r\n{-} The other two closest Imperial figures become <color=\"red\">Focused</color>.",
           "GUID": "f31ec38b-7744-4f81-b0bb-0260839d83fa",
           "eventActionType": 11,

--- a/Assets/sources/Missions/Core/CORE6_EN.json
+++ b/Assets/sources/Missions/Core/CORE6_EN.json
@@ -329,6 +329,12 @@
           "eaName": "Change Objective"
         },
         {
+          "otherTarget": null,
+          "GUID": "f64233e3-a718-4f90-905d-3bf5c6836072",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "repositionText": "Block access to the Exit.",
           "GUID": "2c901212-a768-41fb-b146-ff128d088447",
           "eventActionType": 17,

--- a/Assets/sources/Missions/Core/CORE7_EN.json
+++ b/Assets/sources/Missions/Core/CORE7_EN.json
@@ -270,6 +270,12 @@
           "eaName": "Text Box"
         },
         {
+          "otherTarget": "the captive",
+          "GUID": "59b25a97-e886-475b-a59f-a471def8fdc8",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "repositionText": "Block access to the exit.",
           "GUID": "3af0142c-341f-4b91-b400-2afab9479cf9",
           "eventActionType": 17,

--- a/Assets/sources/Missions/Empire/EMPIRE13_EN.json
+++ b/Assets/sources/Missions/Empire/EMPIRE13_EN.json
@@ -81,6 +81,12 @@
       "eventText": "By the time you reach the scene, chaos has already engulfed the streets. Civilians cower behind what cover they can find, desperate to escape the Empire's towering war machines.\r\n\r\n{-} Deploy the heroes to the Rebel mission token.",
       "eventActions": [
         {
+          "otherTarget": "the closest civilian",
+          "GUID": "13df9421-7be5-4584-a465-b28dbe6f0a1d",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "Former protesters cower in fear or sprint for cover.\r\n\r\n{-} Place 1 neutral mission token on each red highlighted space.\r\n{-} Neutral mission tokens represent civilians. Civilians are neutral figures. Imperial figures can attack civilians (Health: 4).\r\n{-} The Rebel mission token represents an escape route. When a civilian enters a space on or adjacent to the escape route, click the escape route and select \"Civilian escapes\".\r\n{-} When a civilian is defeated, click the escape route and select \"Civilian defeated\".\r\n{-} At the end of a hero's activation, that hero may move a civilian within 2 spaces up to 2 spaces.",
           "GUID": "561387f9-553b-46ec-a660-6061017be9d0",
           "eventActionType": 16,
@@ -150,6 +156,12 @@
       "GUID": "0bb9fb9f-d9a4-489f-a1c7-0ea302f87cfe",
       "eventText": "As reinforcements close in, remaining protesters attempt to huddle in safety. Your pilot zooms overhead, launching an EMP blast targeting the AT-DP's shield generators.\r\n\r\nWith its weaknesses now revealed, you aim your weapons and prepare to take down the less-intimidating walker.\r\n\r\n{-} The <color=\"red\">AT-DP</color> can now suffer {H}.\r\n{-} The Rebels win when the <color=\"red\">AT-DP</color> is defeated.",
       "eventActions": [
+        {
+          "otherTarget": null,
+          "GUID": "983c4f28-68df-42d9-a8e7-cff7cbc9ced2",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
         {
           "shortText": "Take down the <color=\"red\">AT-DP</color>.",
           "longText": null,

--- a/Assets/sources/Missions/Empire/EMPIRE3_EN.json
+++ b/Assets/sources/Missions/Empire/EMPIRE3_EN.json
@@ -106,6 +106,12 @@
       "eventText": "“Your reputation precedes you, Maul,” Zaaryn says in the transmission you intercepted. “I am willing to deal, but you must do something for me first to prove your good faith. Help me quash this unrest, and then we'll talk.\"\r\n\r\nYou arrive at the meeting coordinates provided in the transmission to find civilians gathered for a protest in the streets.",
       "eventActions": [
         {
+          "otherTarget": "the closest protester",
+          "GUID": "d53c4103-7ecc-48fe-92b8-835d41cbcc1d",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "translatedEntityProperties": [
             {
               "entityName": "Protester 1",
@@ -1823,6 +1829,12 @@
           "GUID": "9d00693d-e7e0-4467-bc3f-119688843f6a",
           "eventActionType": 2,
           "eaName": "Change Objective"
+        },
+        {
+          "otherTarget": null,
+          "GUID": "a921c557-f8b3-47c1-b409-1c00ebc1aa75",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },

--- a/Assets/sources/Missions/Hoth/HOTH12_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH12_EN.json
@@ -159,6 +159,12 @@
       "eventText": "Finally, the door to the containment area bursts open. Behind lies a large room where everything is being prepared for the execution.",
       "eventActions": [
         {
+          "otherTarget": "Draylen",
+          "GUID": "21a17bc4-7ff4-40e2-bf2a-74cd27c4d5d3",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "repositionText": "Block access to the evacuation point.",
           "GUID": "0be64fde-67df-477e-91eb-9fd7f5ab485f",
           "eventActionType": 17,

--- a/Assets/sources/Missions/Hoth/HOTH13_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH13_EN.json
@@ -262,6 +262,12 @@
           "eaName": "Text Box"
         },
         {
+          "otherTarget": "the shuttle door",
+          "GUID": "90cbc99c-329c-4aca-9116-4acc91318ec7",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "repositionText": "Move to the Shuttle.",
           "GUID": "3978e551-8df7-426d-b5d3-0a39ff020cc0",
           "eventActionType": 17,
@@ -324,6 +330,12 @@
           "GUID": "3170c859-2774-44a4-ab2a-b37a836744a1",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": null,
+          "GUID": "7df5e828-1d5a-42f0-9721-1f8fc5587358",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },

--- a/Assets/sources/Missions/Hoth/HOTH16_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH16_EN.json
@@ -247,6 +247,12 @@
           "eaName": "Deploy: DG016/Trandoshan Hunter (Elite)"
         },
         {
+          "otherTarget": null,
+          "GUID": "7fb9ab79-50fa-46bd-89cd-3b3f959e801c",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "enemyName": null,
           "customText": "",
           "modification": null,

--- a/Assets/sources/Missions/Hoth/HOTH1_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH1_EN.json
@@ -654,6 +654,12 @@
       "eventText": "Now that you can see better how much people there are still left, you realize you won't be able to save everyone. You hurry forward, dedicated to rescue as many as possible.\r\n\r\n{-} Heroes gain {A}: Push an adjacent evacuee up to 4 spaces.\r\n{-} At the start of each Round, the Rebels rescue a liberated evacuee. Then, they may move each additional liberated evacuee up to 4 spaces. Evacuees cannot end their movement in a space containing another evacuee.\r\n{-} An Imperial figure can attack an evacuee (Health: 5, Defense: None). While an evacuee adjacent to a healthy hero is defending, it adds 1 white die to its defense pool. When an evacuee is defeated, the Empire claims that evacuee. Click the red highlight and select \"Evacuee defeated\".\r\n{-} The Rebels win when the Rebel players have rescued 6 evacuees.",
       "eventActions": [
         {
+          "otherTarget": "the closest evacuee",
+          "GUID": "3ab08684-de77-43ea-ae8c-70a85da46bb4",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "translatedEntityProperties": [
             {
               "entityName": "Empire Highlight",

--- a/Assets/sources/Missions/Hoth/HOTH2_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH2_EN.json
@@ -465,6 +465,12 @@
           "eaName": "Deploy: DG004/Imperial Officer"
         },
         {
+          "otherTarget": "the closest refugee",
+          "GUID": "068bca4a-baa3-486d-b916-a28d87047712",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "newInstructions": "{-} Imperial figures will attack a door if it is the shortest direct way to their target.",
           "GUID": "16dce7d9-9440-432a-b77c-b16af74ee74c",
           "eventActionType": 11,

--- a/Assets/sources/Missions/Hoth/HOTH8_EN.json
+++ b/Assets/sources/Missions/Hoth/HOTH8_EN.json
@@ -112,6 +112,12 @@
           "eaName": "Change Group Instructions"
         },
         {
+          "otherTarget": "the closest defense checkpoint",
+          "GUID": "ca525fcf-8102-4ca5-a1d9-8835fa830428",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "enemyName": null,
           "customText": "",
           "modification": null,
@@ -466,6 +472,12 @@
           "GUID": "985d8664-0483-4c86-9f9e-7c5f6506f22c",
           "eventActionType": 11,
           "eaName": "Change Group Instructions"
+        },
+        {
+          "otherTarget": "the siege wall",
+          "GUID": "bbb4da19-20f0-4f57-bef8-281d8adab839",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         },
         {
           "newInstructions": "{-} When a healthy Rebel figure is adjacent to the siege wall that is the target of an attack, that Rebel figure becomes the target of the attack.\r\n{-} When BOMBARD is not the bonus effect, this figure gains \"BOMBARD: This figure's attacks do not require line of sight or Accuracy.\" When BOMBARD is the bonus effect, this figure gains 1 {g}.\r\n{-} DEFENSIBLE: Recover 3 {H}.\r\n{Q}{A} Attack the siege wall. Then, attack the healthy Rebel closest to the siege wall.\r\n{Q} Attack the siege wall.\r\n{A} If this figure has suffered {H}, it recovers 3 {H}.\r\n{A} If this figure has suffered {H}, it recovers 3 {H}.",

--- a/Assets/sources/Missions/Jabba/JABBA3_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA3_EN.json
@@ -636,6 +636,12 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "otherTarget": null,
+          "GUID": "defcfe45-6777-4c22-8502-b2d5950c4735",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "shortText": "Get to the Extraction Zone.",
           "longText": null,
           "GUID": "4ea33412-7d28-4f39-ad6a-0fe567ce2f38",

--- a/Assets/sources/Missions/Jabba/JABBA5_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA5_EN.json
@@ -106,6 +106,12 @@
       "eventText": "You depart the skiff at a warehouse on the outskirts of Mos Eisley. You meet a hooded Gotal, who ignores your introduction and hands you a barrel. When you try to peek inside the package he slaps your hand. “No questions,” he bleats. “Just work.” He points to a stack of similar barrels, then to his YV-666 outside. Before long, the crates are loaded and you depart.\r\n\r\nAs you approach a ruined temple you note several mercenaries stationed throughout the Dosha jungle.",
       "eventActions": [
         {
+          "otherTarget": "a Rebel figure carrying a spice barrel",
+          "GUID": "2d38f322-40a2-40b8-add9-63358d5a3d00",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "enemyName": null,
           "customText": "",
           "modification": null,

--- a/Assets/sources/Missions/Jabba/JABBA6_EN.json
+++ b/Assets/sources/Missions/Jabba/JABBA6_EN.json
@@ -939,6 +939,12 @@
           "eaName": "Text Box"
         },
         {
+          "otherTarget": "the closest weak point",
+          "GUID": "d2da4480-b0ea-48f2-888c-cf7096ef23ec",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "shortText": "Defend the base. Weak points destroyed: &Weak Points&/4.",
           "longText": null,
           "GUID": "1957ce84-03ad-49e2-a62d-187f143577a8",

--- a/Assets/sources/Missions/Other/OTHER10_EN.json
+++ b/Assets/sources/Missions/Other/OTHER10_EN.json
@@ -176,6 +176,12 @@
           "eaName": "Text Box"
         },
         {
+          "otherTarget": null,
+          "GUID": "07f06828-5979-448b-a1f0-0892cc892004",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "newInstructions": "{-} If the target of an attack is <color=\"red\">Leia Organa</color>, but she cannot be attacked, the attack instead targets the healthy hero closest to <color=\"red\">Leia Organa</color>.",
           "GUID": "17e6113a-6e54-48ac-8c27-77750598b11c",
           "eventActionType": 11,

--- a/Assets/sources/Missions/Other/OTHER11_EN.json
+++ b/Assets/sources/Missions/Other/OTHER11_EN.json
@@ -67,6 +67,12 @@
           "eaName": "Change Group Instructions"
         },
         {
+          "otherTarget": "the closest refugee",
+          "GUID": "7cbe22e8-fe3a-4123-9327-e6f609fead9d",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "The refugees you managed to get to the safehouse are tired, exhausted, and frightened.",
           "GUID": "f19b5727-8c36-4dd7-b7d4-d84948cb82a7",
           "eventActionType": 16,
@@ -332,6 +338,12 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "otherTarget": "the Force-sensitive refugee",
+          "GUID": "133c12d8-b6e6-497b-8b05-a95a08bc7915",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "\"That's the one!\", an officer shouts, and the Imperials surge forward.\r\n\r\n{-} The two Imperial figures with the highest figure cost move 3 toward the Force-sensitive refugee.",
           "GUID": "fe216127-fbfd-45f8-a4e1-8721bec6252a",
           "eventActionType": 16,
@@ -398,6 +410,12 @@
           "GUID": "76a3532e-493f-41c8-9f97-40af56d186be",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": "the Force-sensitive refugee",
+          "GUID": "f0399c7b-fdb8-4784-b07b-3d296b07f27e",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         },
         {
           "tbText": "\"That's the one!\", an officer shouts, and the Imperials surge forward.\r\n\r\n{-} The two Imperial figures with the highest figure cost move 3 toward the Force-sensitive refugee.",
@@ -644,6 +662,12 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "otherTarget": "the Force-sensitive refugee",
+          "GUID": "778564bd-e2f4-4808-aaf5-edd2a68887b0",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "\"That's the one!\", an officer shouts, and the Imperials surge forward.\r\n\r\n{-} The two Imperial figures with the highest figure cost move 3 toward the Force-sensitive refugee.",
           "GUID": "f49738d1-ddc0-459d-b5e2-b4c6cadd0a0b",
           "eventActionType": 16,
@@ -679,6 +703,12 @@
           "GUID": "86e127d4-1ed7-4d73-8240-e62637d6e1c9",
           "eventActionType": 15,
           "eaName": "Modify Map Entity"
+        },
+        {
+          "otherTarget": "the Force-sensitive refugee",
+          "GUID": "14fefc98-1bcf-49e0-b231-be68c14282ca",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         },
         {
           "tbText": "\"That's the one!\", an officer shouts, and the Imperials surge forward.\r\n\r\n{-} The two Imperial figures with the highest figure cost move 3 toward the Force-sensitive refugee.",

--- a/Assets/sources/Missions/Other/OTHER16_EN.json
+++ b/Assets/sources/Missions/Other/OTHER16_EN.json
@@ -290,6 +290,12 @@
           "eaName": "Change Objective"
         },
         {
+          "otherTarget": "the Rebel carrying the supplies",
+          "GUID": "78abc363-5f08-4be9-9561-6fb931b8128e",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "translatedEntityProperties": [
             {
               "entityName": "Terminal 1",

--- a/Assets/sources/Missions/Other/OTHER20_EN.json
+++ b/Assets/sources/Missions/Other/OTHER20_EN.json
@@ -183,6 +183,12 @@
           "GUID": "4778fdc1-96a4-4359-a9b1-5b3cc024b1ef",
           "eventActionType": 17,
           "eaName": "Change Reposition Instructions"
+        },
+        {
+          "otherTarget": "the hero carrying the access disk",
+          "GUID": "34da466d-1db4-403c-8ee7-b6bed4b51536",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },

--- a/Assets/sources/Missions/Other/OTHER27_EN.json
+++ b/Assets/sources/Missions/Other/OTHER27_EN.json
@@ -93,6 +93,12 @@
           "eaName": "Ally Deployment"
         },
         {
+          "otherTarget": null,
+          "GUID": "428ba42f-8159-4e46-ad77-affaf3e7507a",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "Some sections of the facility wall have already crumbled, opening passages into the building.",
           "GUID": "bdff2562-1ed1-45e3-93d8-489e536304ad",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Other/OTHER33_EN.json
+++ b/Assets/sources/Missions/Other/OTHER33_EN.json
@@ -464,6 +464,12 @@
           "eaName": "Change Reposition Instructions"
         },
         {
+          "otherTarget": "the Rebel carrying the prototype",
+          "GUID": "31293544-e57e-4e6e-95fa-67bfccdadcc6",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "shortText": "Open the door.",
           "longText": null,
           "GUID": "18fe9c23-0973-47aa-b17a-a70af8efc2ca",

--- a/Assets/sources/Missions/Other/OTHER3_EN.json
+++ b/Assets/sources/Missions/Other/OTHER3_EN.json
@@ -81,6 +81,12 @@
       "eventText": "You are here with a pair of Duros to destroy a new warship prototype the Empire is preparing to launch. You walk through the sewers toward the Imperial testing ground, hoping you remain unnoticed. After a while, the Duros stop you.\r\n\r\n{-} Deploy the Rebel Saboteurs to the red highlighted spaces.\r\n{-} Deploy the heroes to the blue highlighted space.",
       "eventActions": [
         {
+          "otherTarget": null,
+          "GUID": "883776c7-3b7b-4876-b848-689ba9a56769",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "customName": null,
           "GUID": "99204e6b-6f24-4be3-b4f2-9f5d4254399a",
           "eventActionType": 7,
@@ -123,7 +129,14 @@
       "eventName": "Rebel Saboteurs Defeated",
       "GUID": "a7aaf8ac-fd21-47d8-972e-6c9b4c6a9c34",
       "eventText": "",
-      "eventActions": []
+      "eventActions": [
+        {
+          "otherTarget": null,
+          "GUID": "747ca8ed-e512-4242-be3d-bd2aa5ca0d68",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        }
+      ]
     },
     {
       "eventName": "Outer Defenses",

--- a/Assets/sources/Missions/Other/OTHER40_EN.json
+++ b/Assets/sources/Missions/Other/OTHER40_EN.json
@@ -79,6 +79,12 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "otherTarget": "the marked hero",
+          "GUID": "21a4b659-01d4-47c7-868e-3df7bb20e4c6",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "{-} The Imperial mission token represents the locked trap door.",
           "GUID": "a7ddc621-8198-42e0-a364-6f0c513fbf5f",
           "eventActionType": 16,

--- a/Assets/sources/Missions/Other/OTHER6_EN.json
+++ b/Assets/sources/Missions/Other/OTHER6_EN.json
@@ -87,6 +87,12 @@
           "eaName": "Ally Deployment"
         },
         {
+          "otherTarget": "the closest barricade",
+          "GUID": "b1ba529a-7c54-49da-a89a-dcc4a605ec55",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "tbText": "The rebel troopers have erected improvised barricades.",
           "GUID": "5a206beb-80d1-4545-a97a-f4c1fd27fa79",
           "eventActionType": 16,
@@ -215,6 +221,12 @@
       "GUID": "f1b8c26d-7d49-41d2-bf3c-0a6ee5ca608e",
       "eventText": "After the last barricades comes crushing down, the way into the Rebel encampment is free for the Empire.",
       "eventActions": [
+        {
+          "otherTarget": null,
+          "GUID": "59e76fd5-9c90-49a7-ae9a-5ad0438cb889",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
         {
           "translatedEntityProperties": [
             {

--- a/Assets/sources/Missions/Twin/TWIN2_EN.json
+++ b/Assets/sources/Missions/Twin/TWIN2_EN.json
@@ -306,6 +306,12 @@
           "eaName": "Modify Map Entity"
         },
         {
+          "otherTarget": "the Rebel carrying the data chip",
+          "GUID": "9cac0e48-ad3a-48b4-92e6-fcda509d426f",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
+        },
+        {
           "repositionText": "Block access to the Docking Bay and the terminal.",
           "GUID": "edbed6ee-3f1e-46e4-8df9-8921962e57cb",
           "eventActionType": 17,

--- a/Assets/sources/Missions/Twin/TWIN3_EN.json
+++ b/Assets/sources/Missions/Twin/TWIN3_EN.json
@@ -277,6 +277,12 @@
           "GUID": "2f3ea816-5375-42ad-9eea-7d0bda9565a0",
           "eventActionType": 2,
           "eaName": "Change Objective"
+        },
+        {
+          "otherTarget": null,
+          "GUID": "7b738c32-be80-4c39-8066-ea726360b3a1",
+          "eventActionType": 12,
+          "eaName": "Change Priority Target"
         }
       ]
     },

--- a/Converters/TranslatedEventActionConverter.cs
+++ b/Converters/TranslatedEventActionConverter.cs
@@ -65,6 +65,9 @@ namespace Saga_Translator_V2.Converters
 					case 21://D6
 						eventActionAction = item.ToObject<TranslatedCustomEnemyDeployment>();
 						break;
+					case 12://GM2
+						eventActionAction = item.ToObject<TranslatedChangeTarget>();
+						break;
 				}
 				eObserver.Add( eventActionAction );
 			}

--- a/Models/MissionFormat/TranslatedMission.cs
+++ b/Models/MissionFormat/TranslatedMission.cs
@@ -506,6 +506,32 @@ namespace Imperial_Commander_Editor
 		}
 	}
 
+	public class TranslatedChangeTarget : ITranslatedEventAction//GM2
+	{
+		public string otherTarget { get; set; }
+		public Guid GUID { get; set; }
+		public EventActionType eventActionType { get; set; }
+		public string eaName { get; set; }
+
+		public TranslatedChangeTarget()
+		{
+
+		}
+
+		public List<string> Validate(ITranslatedEventAction loadedEA, bool useLooseValidation = false)
+		{
+			var problems = new List<string>();
+
+			//check if value is translated
+			if (!string.IsNullOrEmpty(otherTarget) && otherTarget == (loadedEA as TranslatedChangeTarget).otherTarget)
+				Utils.missingTranslations.Add(loadedEA.GUID);
+
+			otherTarget = (loadedEA as TranslatedChangeTarget).otherTarget;
+
+			return problems;
+		}
+	}
+
 	public class TranslatedCustomEnemyDeployment : ITranslatedEventAction//D6
 	{
 		public Guid GUID { get; set; }

--- a/TranslatePanels/MissionPanel.xaml.cs
+++ b/TranslatePanels/MissionPanel.xaml.cs
@@ -241,6 +241,9 @@ namespace Saga_Translator_V2
 					case EventActionType.D6:
 						MissionPanelUIHelper.CreateD6( eaIdx, dataSource, panel, isEnabled, useContext );
 						break;
+					case EventActionType.GM2:
+						MissionPanelUIHelper.CreateGM2(eaIdx, dataSource, panel, isEnabled, useContext);
+						break;
 				}
 			}
 		}


### PR DESCRIPTION
More details about the issue in : https://github.com/GlowPuff/ICEditor/pull/19

Fix is multi-level:
 - part1 : ICEditor :  in order for otherTarget to correctly be exported into the translation files.
(PR for Part1: https://github.com/GlowPuff/ICEditor/pull/19)

 - **part2 : SagaTranslatorModern : to allow translators to translate these otherTargets.**
 - part3 : ImperialCommander2 : to correctly display the translated otherTargets.

Current PR is part2

--------------------
Side note: "otherTarget" is sometimes set to Null.

I made it so that in such cases, otherTarget won't be displayed in the TranslatorApp but the value will correctly be copied in the translation json file. (It is to avoid any translators to potentially change Null to "", as I don't know if it can have an impact on IC2 code/missions, but I guess it could as Null and "" are 2 different things. So, better be safe than sorry.)

Small side effect : The first time one of the _already fully translated_ file will be opened, it will display a warning saying that a translation is missing (indeed the otherTarget:Null will be missing in target translation file), but the app will not show anything to be changed. Saving the file will correctly update the target file, so **this warning will only appears once** for these 9 files : Bespin6, Core20, Core6, Hoth16, Jabba3, Other10, Other27, Other3, Twin3.