### PR TITLE
Adding Extra to rewards

### DIFF
--- a/TranslatePanels/CampaignRewardsPanel.xaml.cs
+++ b/TranslatePanels/CampaignRewardsPanel.xaml.cs
@@ -43,6 +43,11 @@ namespace Saga_Translator_V2
 			{
 				source[index].name = (a as TextBox).Text.Trim();
 			} ) );
+			panel.Children.Add(UIFactory.TBlock("Extra"));
+			panel.Children.Add(UIFactory.TBox(source[index].extra, "", false, isEnabled, (a, b) =>
+			{
+				source[index].extra = (a as TextBox).Text.Trim();
+			}));
 		}
 
 		public override void PopulateUIMainTree()


### PR DESCRIPTION
Adding Extra to rewards so that "boons" can be translated (it is displayed in IC2's reward selection window, during campaign setup)