### PR TITLE
Fixing event text to match proper droid color in Lothal5

### DIFF
--- a/Assets/sources/Missions/Lothal/LOTHAL5_EN.json
+++ b/Assets/sources/Missions/Lothal/LOTHAL5_EN.json
@@ -384,7 +384,7 @@
           "surges": "",
           "bonuses": "",
           "keywords": "",
-          "abilities": "BATTLE DROID: Once during their activation, a hero can command the blue battle droid. That hero may push the battle droid up to 3 spaces. Then, they may choose a figure within 3 spaces and in line of sight of the battle droid and roll 1 blue die. That figure suffers {H} equal to the {H}  results. Each battle droid can be commanded once per round.",
+          "abilities": "BATTLE DROID: Once during their activation, a hero can command the red battle droid. That hero may push the battle droid up to 3 spaces. Then, they may choose a figure within 3 spaces and in line of sight of the battle droid and roll 1 blue die. That figure suffers {H} equal to the {H}  results. Each battle droid can be commanded once per round.",
           "customText": "",
           "cardName": "Red Battle Droid",
           "GUID": "6dfc24b6-ceb6-405e-af35-489245df753a",


### PR DESCRIPTION
Fixing event text to match proper droid color in Lothal5